### PR TITLE
Error in getAggregatedStats

### DIFF
--- a/src/com/achimala/leaguelib/services/PlayerStatsService.java
+++ b/src/com/achimala/leaguelib/services/PlayerStatsService.java
@@ -43,7 +43,7 @@ public class PlayerStatsService extends LeagueAbstractService {
     }
     
     public void fillRankedStats(final LeagueSummoner summoner, final Callback<LeagueSummoner> callback) {
-        callAsynchronously("getAggregatedStats", new Object[] { summoner.getAccountId(), SUMMONERS_RIFT, LeagueCompetitiveSeason.CURRENT.toString() }, new Callback<TypedObject>() {
+        callAsynchronously("getAggregatedStats", new Object[] { summoner.getAccountId(), SUMMONERS_RIFT, LeagueCompetitiveSeason.CURRENT.getNumber() }, new Callback<TypedObject>() {
             public void onCompletion(TypedObject obj) {
                 try {
                     summoner.setRankedStats(new LeagueSummonerRankedStats(obj.getTO("body")));


### PR DESCRIPTION
I receive this error because the service of Riot only expects an integer as the above call. Am I missing anything?

Invoke:{result=_error, serviceCall=null, invokeId=11, data=flex.messaging.messages.ErrorMessage:{timestamp=1.383683364499E12, rootCause=flex.messaging.messages.ErrorMessage:{timestamp=1.383683364499E12, rootCause=null, headers=:{}, extendedData=null, body=null, faultDetail=null, correlationId=null, faultCode=Client.Message.Deserialize.InvalidType, messageId=886E239C-E30E-A7DC-932C-D4E281161CDB, faultString=Cannot convert type java.lang.String with value 'CURRENT' to an instance of int, timeToLive=0.0, clientId=null, destination=null}, headers=:{}, extendedData=null, body=null, faultDetail=The expected argument types are (long, com.riotgames.platform.game.GameMode, int) but the supplied types were (java.lang.Integer, java.lang.String, java.lang.String) and converted to (java.lang.Long, com.riotgames.platform.game.GameMode, null)., correlationId=C3A1A3C3-C693-6FED-99B1-0531FC47CA16, faultCode=Server.ResourceUnavailable, messageId=886E239A-722C-0A27-62A1-7029FEE604EA, faultString=Cannot invoke method 'getAggregatedStats'., timeToLive=0.0, clientId=886E2386-EA2B-B848-B690-1D4A3C5743C7, destination=playerStatsService}, version=0}
