### PR TITLE
Added Season 4 to fix error while consulting  ranked stats

### DIFF
--- a/src/com/achimala/leaguelib/models/LeagueCompetitiveSeason.java
+++ b/src/com/achimala/leaguelib/models/LeagueCompetitiveSeason.java
@@ -19,7 +19,8 @@ package com.achimala.leaguelib.models;
 public enum LeagueCompetitiveSeason {
     ONE(1),
     TWO(2),
-    CURRENT(3);
+	THREE(3),
+    CURRENT(4);
 
     private int _number;
 


### PR DESCRIPTION
Now with the new season 4 if you are trying to get ranked stats you will have an error of message service from getAggregatedStats.   The solution for me was add the new season 4 to the Model LeagueCompetitiveSeason.
